### PR TITLE
Ajustar navegação para editar formulário

### DIFF
--- a/src/main/webapp/controller/index.js
+++ b/src/main/webapp/controller/index.js
@@ -53,18 +53,22 @@
             e.preventDefault();
             e.stopImmediatePropagation();
 
+            console.log(e.currentTarget.attributes);
+            
+            var nrId = parseInt(e.currentTarget.getAttribute('data-id') ||'0');
+            var txtServico = e.currentTarget.getAttribute('data-servico');
+            var txtKey = e.currentTarget.getAttribute('data-key');
 
             abrirPagina(e.currentTarget.href, '#conteudo');
 
-            $('#conteudo form').each((index, formulario) => {
+            setTimeout(() =>            $('#conteudo form').each((index, formulario) => {
 
-                var cdCliente = Number($(e.currentTarget.href).attr('data-id'));
-                enviarAjax('<caminho do restful para obter clientes>',
+                enviarAjax(`/SistemaLanchonete/services/${txtServico}/${nrId}`,
                     'GET',
-                    { 'cdCliente': cdCliente },
+                    { txtKey: nrId },
                     res => setFormCampos(formulario, res),
-                    prFailCallBack);
-            });
+                    res => console.error(res));
+            }), 500);
 
             return false;
         });

--- a/src/main/webapp/controller/sistema.js
+++ b/src/main/webapp/controller/sistema.js
@@ -64,7 +64,7 @@ function enviarAjax(prUrl, prMethod, prDados, prDoneCallBack, prFailCallBack) {
         alert('página não encontrada');
     });
     return $.ajax({
-        url: prUrl.toLocaleLowerCase(),
+        url: prUrl,
         type: prMethod.toUpperCase(),
         headers: {
             'Cache-Control': 'no-cache',
@@ -129,7 +129,7 @@ function setFormCampos(prForm, prJSON) {
     while (prForm[n]) {
         var txtNome = prForm[n].name;
 
-        prForm[n].value = prJson[txtNome];
+        prForm[n].value = prJSON[txtNome];
 
 
         n++;


### PR DESCRIPTION
Estas alteraç;oes s;ao para atender ao Everton, e para melhorar de forma genérica a ediç;ao de clientes, produtos, ...

Preciso que o pessoal do HTML altere as names dos forms para que sejam equivalentes as chaves do JSON que é retornado pelo restful. Nas grids de consulta, os botoes de editar deverao estar dentro de uma tag a contendo a seguinte sintaxe:
<a href="<pagina do formulário>" data-id="<código do item>" data-servico="<o nome do serviço de rest>" data-key="<chave do codigo do item>" > ... </a>

Ex.:
<a href="CadastroCliente.html" data-id="12" data-servico="cliente" data-key="cdCliente" > ... </a>

Qualquer dúvida, estou à disposiç;ao.